### PR TITLE
Created custom Action Component to use iconButton() option

### DIFF
--- a/resources/views/components/drop-in-action.blade.php
+++ b/resources/views/components/drop-in-action.blade.php
@@ -22,7 +22,7 @@
             <x-forms::actions.action
                 :action="$executableAction"
                 class="flex items-center"
-                component="forms::button"
+                component="{{$executableAction->getView()}}"
             >
                 @if (!$executableAction->isLabelHidden())
                     {{ $executableAction->getLabel() }}

--- a/src/Forms/Components/Actions/Action.php
+++ b/src/Forms/Components/Actions/Action.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Awcodes\DropInAction\Forms\Components\Actions;
+
+use Filament\Forms\Components\Actions\Action as BaseAction;
+
+class Action extends BaseAction
+{
+    protected string $view = 'forms::button';
+
+    public function iconButton(): static
+    {
+        $this->view('forms::icon-button');
+
+        return $this;
+    }
+}

--- a/src/Forms/Components/DropInAction.php
+++ b/src/Forms/Components/DropInAction.php
@@ -10,8 +10,8 @@ use Illuminate\Support\Arr;
 class DropInAction extends Field
 {
     /** @var array<Action|Closure> */
-    protected array $actions          = [];
-    private array   $evaluatedActions = [];
+    protected array $actions = [];
+    private array $evaluatedActions = [];
 
     protected string $view = 'drop-in-action::components.drop-in-action';
 
@@ -32,14 +32,21 @@ class DropInAction extends Field
     /** @return array<Action|Closure> */
     public function getExecutableActions(bool $reevaluate = false): array
     {
-        if ((! $reevaluate) && $this->evaluatedActions) {
+        if ((!$reevaluate) && $this->evaluatedActions) {
             return $this->evaluatedActions;
         }
 
         $this->evaluatedActions = [];
 
         foreach ($this->actions as $action) {
-            $this->evaluatedActions[] = $this->evaluate($action)?->component($this);
+            $evaluatedAction = $this->evaluate($action)?->component($this);
+
+            // To add compatibility with base \Filament\Forms\Components\Actions\Action
+            if (!$evaluatedAction instanceof \Awcodes\DropInAction\Forms\Components\Actions\Action) {
+                $evaluatedAction->view('forms::button');
+            }
+
+            $this->evaluatedActions[] = $evaluatedAction;
         }
 
         return $this->evaluatedActions;


### PR DESCRIPTION
I needed the iconButton functionality, but it doesn't work in the base Action component (It seems to be in a WIP status in the base Filament code). So I created a custom `\Awcodes\DropInAction\Forms\Components\Actions\Action` that assigns the correct view when you call `iconButton()`.

```
\Awcodes\DropInAction\Forms\Components\Actions\Action::make('perform-action')
          ->icon('heroicon-o-pencil')
          ->iconButton()
          ->action(function () use ($get, $set) {
          })->form([
              Forms\Components\Select::make('authorId')
                  ->label('Author')
                  ->options([1, 2, 3])
                  ->required(),
          ]);
  }),
```

It also supports the current base Action Component, without the iconButton functionality of course.