### PR TITLE
permit closures to return more than one action

### DIFF
--- a/src/Forms/Components/DropInAction.php
+++ b/src/Forms/Components/DropInAction.php
@@ -41,8 +41,8 @@ class DropInAction extends Field
         foreach ($this->actions as $action) {
             $actions = $this->evaluate($action);
 
-            foreach (Arr::wrap($actions) as $action) {
-                $this->evaluatedActions[] = $this->evaluate($action)?->component($this);
+            foreach (Arr::wrap($actions) as $nestedAction) {
+                $this->evaluatedActions[] = $this->evaluate($nestedAction)?->component($this);
             }
         }
 

--- a/src/Forms/Components/DropInAction.php
+++ b/src/Forms/Components/DropInAction.php
@@ -39,7 +39,11 @@ class DropInAction extends Field
         $this->evaluatedActions = [];
 
         foreach ($this->actions as $action) {
-            $this->evaluatedActions[] = $this->evaluate($action)?->component($this);
+            $actions = $this->evaluate($action);
+
+            foreach (Arr::wrap($actions) as $action) {
+                $this->evaluatedActions[] = $this->evaluate($action)?->component($this);
+            }
         }
 
         return $this->evaluatedActions;


### PR DESCRIPTION
Permits an `execute` closure to return more than one action.

```
DropInAction::make('actions')
    ->execute(function(\Closure $get, \Closure $set) {
        return [
            Forms\Components\Actions\Action::make('save')
                ->action(function () use ($get, $set) {}),

            Forms\Components\Actions\Action::make('delete')
                ->action(function () use ($get, $set) {}),
        ];
    })
```