### PR TITLE
Enable usage of ->inlineLabel() by switching to x-dynamic-component.

### DIFF
--- a/resources/views/components/drop-in-action.blade.php
+++ b/resources/views/components/drop-in-action.blade.php
@@ -1,4 +1,5 @@
-<x-forms::field-wrapper
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
     :id="$getId()"
     :label="$getLabel()"
     :label-sr-only="$isLabelHidden()"
@@ -30,4 +31,4 @@
             </x-forms::actions.action>
         @endforeach
     </div>
-</x-forms::field-wrapper>
+</x-dynamic-component>


### PR DESCRIPTION
Hey!

I've been using this package for a while (but have since "ejected" and made my own).
One of the reasons was that we use `->inlineLabel()` all over the place and it wasn't supported by this package out of the box.

This was because the view uses `x-forms::field-wrapper` directly instead of using `x-dynamic-component` and `$getFieldWrapperView()`. AFAIK, the latter is how most of the Filament components do it.

I have updated the view and submitted this PR, so other people can enjoy the beauty of inline labels as well :) 

Thanks a lot for your work!